### PR TITLE
Support workspace:*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 - yarn-why now takes a second optional argument to limit which versions to search for
 - fixed a bug detecting dependencies on newer versions of yarn.lock
 - fix duplication caused by dependencies using patch protocol
+- support monorepos
 
 ## [1.0.0-rc3] - 2022-08-01
 
 ### Added
+
 - display the output as an ASCII tree
 - new option `--dedup` to remove duplicate results
 - colorize output when using a TTY
@@ -19,14 +21,22 @@
 ## [1.0.0-rc2] - 2022-05-10
 
 ### Added
+
 - add option -y to to read yarn.lock from a given path
+
 ### Doc
+
 - add some benchmarks
 - better help output
+
 ### CI
+
 - automatically merge dependencies that pass tests
+
 ### Chore
+
 - updated dependencies
 
 ## [1.0.0-rc1] - 2022-05-02
+
 - first release

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,6 +291,9 @@ fn main() -> Result<()> {
             // out there. In general, we should stop stripping it in yarn-lock-parser
             *dep = (dep.0, dep.1.strip_prefix("npm:").unwrap_or(dep.1));
 
+            // XXX Turns out we need to also strip `worskpace:`
+            *dep = (dep.0, dep.1.strip_prefix("workspace:").unwrap_or(dep.1));
+
             // hacky way to detect patch protocol (we must drop them from entries
             // otherwise we will get duplicates)
             !dep.1.contains('#') || dep.1.contains("git")

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,17 +176,6 @@ fn why<'a>(
 #[derive(Debug)]
 struct Parents<'a>(Vec<&'a (&'a str, &'a str)>);
 
-fn get_descriptor_from_cli_arg(arg: &str) -> Option<(&str, &str)> {
-    if let Some(idx) = arg.rfind('@') {
-        // skip @foo/bar, keep @foo/bar@1.0.0
-        if idx > 0 {
-            return Some((&arg[0..idx], &arg[idx + 1..]));
-        }
-    }
-
-    None
-}
-
 fn parse_path(s: &std::ffi::OsStr) -> Result<std::path::PathBuf, &'static str> {
     Ok(s.into())
 }


### PR DESCRIPTION
Support monorepos (handle `workspace:*`)